### PR TITLE
fix: add generic type hints to dependency descriptors

### DIFF
--- a/src/prion/_internal/dependency.py
+++ b/src/prion/_internal/dependency.py
@@ -1,36 +1,41 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from prion.syringe import Syringe
 
+T = TypeVar("T")
 
-class DependencyState:
+
+class DependencyState(Generic[T]):
     __slots__ = ("_strategy", "_provider", "_value", "_resolved")
 
     def __init__(self, strategy: str) -> None:
         self._strategy = strategy
-        self._provider: Callable[..., Any] | None = None
-        self._value: Any = None
+        self._provider: Callable[..., T] | None = None
+        self._value: T | None = None
         self._resolved = False
 
-    def __call__(self, provider: Callable[..., Any]) -> Callable[..., Any]:
+    def __call__(self, provider: Callable[..., T]) -> Callable[..., T]:
         self._provider = provider
         return provider
 
-    def resolve(self) -> Any:
+    def resolve(self) -> T:
         if self._provider is None:
             raise RuntimeError("no provider registered for this dependency")
         if self._strategy == "single":
             if not self._resolved:
                 self._value = self._provider()
                 self._resolved = True
+            assert self._value is not None
             return self._value
         return self._provider()
 
 
-class Dependency:
+class Dependency(Generic[T]):
     __slots__ = ("_strategy", "_attr")
 
     def __init__(self, strategy: str) -> None:
@@ -40,12 +45,18 @@ class Dependency:
     def __set_name__(self, owner: type, name: str) -> None:
         self._attr = name
 
+    @overload
+    def __get__(self, obj: None, objtype: type | None = None) -> Self: ...
+
+    @overload
+    def __get__(self, obj: Syringe, objtype: type | None = None) -> DependencyState[T]: ...
+
     def __get__(self, obj: Syringe | None, objtype: type | None = None) -> Any:
         if obj is None:
-            return self
+            return self  # type: ignore[return-value]
         state = obj._dependencies.get(self._attr)
         if state is None:
-            state = DependencyState(self._strategy)
+            state = DependencyState[T](self._strategy)
             obj._dependencies[self._attr] = state
         if state._provider is None:
             return state

--- a/src/prion/syringe.py
+++ b/src/prion/syringe.py
@@ -1,19 +1,27 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from prion._internal.dependency import Dependency, DependencyState
+
+T = TypeVar("T")
 
 
 class Syringe:
 
     def __init__(self) -> None:
-        self._dependencies: dict[str, DependencyState] = {}
+        self._dependencies: dict[str, DependencyState[Any]] = {}
 
 
-def single() -> Any:
-    return Dependency("single")
+class single(Dependency[T], Generic[T]):
+    """Singleton dependency — provider is called once, result is cached."""
+
+    def __init__(self) -> None:
+        super().__init__("single")
 
 
-def factory() -> Any:
-    return Dependency("factory")
+class factory(Dependency[T], Generic[T]):
+    """Factory dependency — provider is called on every access."""
+
+    def __init__(self) -> None:
+        super().__init__("factory")

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -6,8 +6,8 @@ from prion import Syringe, factory, single
 
 
 class Container(Syringe):
-    value: str = single()
-    creator: str = factory()
+    value = single[str]()
+    creator = factory[str]()
 
 
 class TestSingle:
@@ -16,7 +16,7 @@ class TestSingle:
 
         @container.value
         def provide() -> str:
-            return object()
+            return "hello"
 
         a = container.value
         b = container.value
@@ -44,7 +44,7 @@ class TestFactory:
 
         @container.creator
         def provide() -> str:
-            return object()
+            return str(id(object()))
 
         a = container.creator
         b = container.creator


### PR DESCRIPTION
## Summary
- Add `Generic[T]` to `Dependency` and `DependencyState` for proper type inference
- Convert `single` / `factory` from functions to generic descriptor classes (`single[str]()`)
- Add `@overload` to `Dependency.__get__` so type checkers recognize `DependencyState[T]`

## Test plan
- [x] `uvx ty check` passes with 0 diagnostics
- [x] `uv run pytest -v` passes all 9 tests