### PR TITLE
feat: add thread-safe singleton caching

### DIFF
--- a/src/prion/_internal/dependency.py
+++ b/src/prion/_internal/dependency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
 
 if TYPE_CHECKING:
@@ -11,13 +12,14 @@ T = TypeVar("T")
 
 
 class DependencyState(Generic[T]):
-    __slots__ = ("_strategy", "_provider", "_value", "_resolved")
+    __slots__ = ("_strategy", "_provider", "_value", "_resolved", "_lock")
 
     def __init__(self, strategy: str) -> None:
         self._strategy = strategy
         self._provider: Callable[..., T] | None = None
         self._value: T | None = None
         self._resolved = False
+        self._lock = threading.Lock()
 
     def __call__(self, provider: Callable[..., T]) -> Callable[..., T]:
         self._provider = provider
@@ -28,8 +30,10 @@ class DependencyState(Generic[T]):
             raise RuntimeError("no provider registered for this dependency")
         if self._strategy == "single":
             if not self._resolved:
-                self._value = self._provider()
-                self._resolved = True
+                with self._lock:
+                    if not self._resolved:
+                        self._value = self._provider()
+                        self._resolved = True
             assert self._value is not None
             return self._value
         return self._provider()

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 from prion import Syringe, factory, single
 
 
@@ -107,3 +109,31 @@ class TestIsolation:
         # factory has no provider registered — returns the slot, not a value
         slot = container.creator
         assert callable(slot)
+
+
+class TestThreadSafety:
+    def test_single_is_thread_safe(self) -> None:
+        container = Container()
+        call_count = 0
+        lock = threading.Lock()
+
+        @container.value
+        def provide() -> str:
+            nonlocal call_count
+            with lock:
+                call_count += 1
+            return "hello"
+
+        results: list[str] = []
+
+        def access() -> None:
+            results.append(container.value)
+
+        threads = [threading.Thread(target=access) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert call_count == 1
+        assert all(r == "hello" for r in results)


### PR DESCRIPTION
## Summary
- Add `threading.Lock` to `DependencyState` for thread-safe singleton resolution
- Use double-checked locking to minimize lock contention
- Add thread safety test with 50 concurrent threads

## Test plan
- [x] `mise run test` passes (10 tests)
- [x] Thread safety test verifies provider called exactly once