### PR TITLE
feat: add dependency wiring with auto-injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 description = "Dependency injection framework using pure Python"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{name = "Geunryeol Park", email = "pkr5207@gmail.com"}]
+authors = [{ name = "Geunryeol Park", email = "pkr5207@gmail.com" }]
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
-  "Topic :: Utilities"
+  "Topic :: Utilities",
 ]
 license = "MIT"
 
@@ -27,6 +27,4 @@ addopts = ["--doctest-glob=*.md"]
 ignore = ["F403"]
 
 [dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-]
+dev = ["pytest>=9.0.2"]

--- a/src/prion/_internal/dependency.py
+++ b/src/prion/_internal/dependency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
 
@@ -12,14 +13,24 @@ T = TypeVar("T")
 
 
 class DependencyState(Generic[T]):
-    __slots__ = ("_strategy", "_provider", "_value", "_resolved", "_lock")
+    __slots__ = (
+        "_strategy",
+        "_provider",
+        "_value",
+        "_resolved",
+        "_lock",
+        "_owner",
+        "_resolving",
+    )
 
-    def __init__(self, strategy: str) -> None:
+    def __init__(self, strategy: str, owner: Syringe) -> None:
         self._strategy = strategy
         self._provider: Callable[..., T] | None = None
         self._value: T | None = None
         self._resolved = False
         self._lock = threading.Lock()
+        self._owner = owner
+        self._resolving = False
 
     def __call__(self, provider: Callable[..., T]) -> Callable[..., T]:
         self._provider = provider
@@ -30,18 +41,35 @@ class DependencyState(Generic[T]):
             raise RuntimeError("no provider registered for this dependency")
         if self._strategy == "single":
             if not self._resolved:
+                value = self._invoke()
                 with self._lock:
                     if not self._resolved:
-                        self._value = self._provider()
+                        self._value = value
                         self._resolved = True
             assert self._value is not None
             return self._value
-        return self._provider()
+        return self._invoke()
 
     def reset(self) -> None:
         with self._lock:
             self._value = None
             self._resolved = False
+
+    def _invoke(self) -> T:
+        assert self._provider is not None
+        if self._resolving:
+            raise RuntimeError("circular dependency detected")
+        self._resolving = True
+        try:
+            params = inspect.signature(self._provider).parameters
+            kwargs: dict[str, Any] = {}
+            for name in params:
+                dep_state = self._owner._dependencies.get(name)
+                if dep_state is not None and dep_state._provider is not None:
+                    kwargs[name] = dep_state.resolve()
+            return self._provider(**kwargs)
+        finally:
+            self._resolving = False
 
 
 class Dependency(Generic[T]):
@@ -67,7 +95,7 @@ class Dependency(Generic[T]):
             return self  # type: ignore[return-value]
         state = obj._dependencies.get(self._attr)
         if state is None:
-            state = DependencyState[T](self._strategy)
+            state = DependencyState[T](self._strategy, obj)
             obj._dependencies[self._attr] = state
         if state._provider is None:
             return state

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from prion import Syringe, factory, single
 
 
@@ -175,3 +177,69 @@ class TestLifecycle:
         # after exit, singleton cache is cleared
         assert container.value == "v2"
         assert call_count == 2
+
+
+class WiredContainer(Syringe):
+    config = single[dict]()
+    greeting = single[str]()
+    message = factory[str]()
+
+
+class TestDependencyWiring:
+    def test_provider_receives_other_dependency(self) -> None:
+        container = WiredContainer()
+
+        @container.config
+        def create_config() -> dict:
+            return {"name": "world"}
+
+        @container.greeting
+        def create_greeting(config: dict) -> str:
+            return f"hello {config['name']}"
+
+        assert container.greeting == "hello world"
+
+    def test_factory_receives_singleton(self) -> None:
+        container = WiredContainer()
+        call_count = 0
+
+        @container.config
+        def create_config() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"v": call_count}
+
+        @container.message
+        def create_message(config: dict) -> str:
+            return f"v{config['v']}"
+
+        assert container.message == "v1"
+        assert container.message == "v1"
+        assert call_count == 1  # config is singleton, called once
+
+    def test_circular_dependency_raises(self) -> None:
+        class Circular(Syringe):
+            a = single[str]()
+            b = single[str]()
+
+        container = Circular()
+
+        @container.a
+        def create_a(b: str) -> str:
+            return f"a({b})"
+
+        @container.b
+        def create_b(a: str) -> str:
+            return f"b({a})"
+
+        with pytest.raises(RuntimeError, match="circular dependency"):
+            _ = container.a
+
+    def test_unknown_params_are_ignored(self) -> None:
+        container = WiredContainer()
+
+        @container.config
+        def create_config(unknown_param: str = "default") -> dict:
+            return {"key": unknown_param}
+
+        assert container.config == {"key": "default"}


### PR DESCRIPTION
## Summary
- Providers can now receive other dependencies as parameters via `inspect.signature`
- Circular dependency detection with clear `RuntimeError`
- Unknown parameters with defaults are ignored gracefully

## Test plan
- [x] `mise run test` passes (15 tests)
- [x] Provider receives resolved dependency as parameter
- [x] Factory receives singleton dependency
- [x] Circular dependency raises RuntimeError
- [x] Unknown params with defaults are ignored