### PR TITLE
feat: add override context manager for test support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      - run: uv sync
       - run: mise run check
 
   test:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ pip install prion
 
 ## Usage
 
-Define a container by subclassing `Syringe` and declaring dependencies with `single()` or `factory()`.
+Define a container by subclassing `Syringe` and declaring dependencies with `single[T]()` or `factory[T]()`.
 
 ```pycon
 >>> from prion import Syringe, single, factory
 
 >>> class AppSyringe(Syringe):
-...     config: dict = single()
-...     session: dict = factory()
+...     config = single[dict]()
+...     session = factory[dict]()
 
 ```
 
@@ -47,12 +47,79 @@ True
 
 ```
 
+## Dependency Wiring
+
+Providers can receive other dependencies as parameters. Parameter names are matched to dependency names automatically.
+
+```pycon
+>>> class WiredSyringe(Syringe):
+...     config = single[dict]()
+...     greeting = single[str]()
+
+>>> syringe = WiredSyringe()
+
+>>> @syringe.config
+... def create_config() -> dict:
+...     return {"name": "world"}
+
+>>> @syringe.greeting
+... def create_greeting(config: dict) -> str:
+...     return f"hello {config['name']}"
+
+>>> syringe.greeting
+'hello world'
+
+```
+
+Circular dependencies are detected at resolve time with a `RuntimeError`.
+
+## Lifecycle
+
+Use `reset()` to clear all cached singletons, or use the container as a context manager.
+
+```pycon
+>>> syringe = AppSyringe()
+
+>>> @syringe.config
+... def create_config() -> dict:
+...     return {"debug": True}
+
+>>> with syringe:
+...     _ = syringe.config
+...
+>>> # singleton cache is cleared after exiting the context
+
+```
+
+## Testing
+
+Use `override()` to temporarily replace a provider in tests.
+
+```pycon
+>>> syringe = AppSyringe()
+
+>>> @syringe.config
+... def create_config() -> dict:
+...     return {"debug": True}
+
+>>> syringe.config
+{'debug': True}
+
+>>> with syringe.override("config", lambda: {"debug": False}):
+...     syringe.config
+{'debug': False}
+
+>>> syringe.config
+{'debug': True}
+
+```
+
 ## Strategies
 
-| Strategy    | Behavior                          |
-| ----------- | --------------------------------- |
-| `single()`  | Creates once, returns cached      |
-| `factory()` | Creates a new instance each time  |
+| Strategy      | Behavior                         |
+| ------------- | -------------------------------- |
+| `single[T]()` | Creates once, returns cached    |
+| `factory[T]()` | Creates a new instance each time |
 
 ## License
 

--- a/src/prion/syringe.py
+++ b/src/prion/syringe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Generic, TypeVar
+from contextlib import contextmanager
+from typing import Any, Generator, Generic, TypeVar
 
 from prion._internal.dependency import Dependency, DependencyState
 
@@ -20,6 +21,24 @@ class Syringe:
 
     def __exit__(self, *args: Any) -> None:
         self.reset()
+
+    @contextmanager
+    def override(self, name: str, provider: Any) -> Generator[None, None, None]:
+        state = self._dependencies.get(name)
+        if state is None:
+            raise KeyError(f"unknown dependency: {name}")
+        old_provider = state._provider
+        old_value = state._value
+        old_resolved = state._resolved
+        state._provider = provider
+        state._value = None
+        state._resolved = False
+        try:
+            yield
+        finally:
+            state._provider = old_provider
+            state._value = old_value
+            state._resolved = old_resolved
 
 
 class single(Dependency[T], Generic[T]):

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -126,7 +126,7 @@ class TestThreadSafety:
                 call_count += 1
             return "hello"
 
-        results: list[str] = []
+        results: list[object] = []
 
         def access() -> None:
             results.append(container.value)

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -243,3 +243,45 @@ class TestDependencyWiring:
             return {"key": unknown_param}
 
         assert container.config == {"key": "default"}
+
+
+class TestOverride:
+    def test_override_replaces_provider(self) -> None:
+        container = Container()
+
+        @container.value
+        def provide() -> str:
+            return "original"
+
+        assert container.value == "original"
+
+        with container.override("value", lambda: "mocked"):
+            assert container.value == "mocked"
+
+        assert container.value == "original"
+
+    def test_override_restores_cached_singleton(self) -> None:
+        container = Container()
+        call_count = 0
+
+        @container.value
+        def provide() -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"v{call_count}"
+
+        assert container.value == "v1"
+
+        with container.override("value", lambda: "mock"):
+            assert container.value == "mock"
+
+        # original cached value is restored, not re-created
+        assert container.value == "v1"
+        assert call_count == 1
+
+    def test_override_unknown_dependency_raises(self) -> None:
+        container = Container()
+
+        with pytest.raises(KeyError, match="unknown dependency"):
+            with container.override("nonexistent", lambda: "x"):
+                pass


### PR DESCRIPTION
## Summary
- Add `Syringe.override()` context manager for temporary provider replacement in tests
- Update README with dependency wiring, lifecycle, and testing examples

## Test plan
- [x] `mise run test` passes (19 tests)
- [x] Override replaces provider and restores on exit
- [x] Override restores cached singleton value
- [x] Override raises KeyError for unknown dependency