### PR TITLE
chore: update package metadata and upgrade uv_build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,22 @@ authors = [{ name = "Geunryeol Park", email = "pkr5207@gmail.com" }]
 classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
   "Topic :: Utilities",
+  "Typing :: Typed",
 ]
+keywords = ["dependency-injection", "di", "ioc"]
 license = "MIT"
+
+[project.urls]
+Homepage = "https://github.com/misut/prion"
+Repository = "https://github.com/misut/prion"
+Issues = "https://github.com/misut/prion/issues"
 
 [build-system]
 requires = ["uv_build>=0.9.26,<0.10.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,11 @@ keywords = ["dependency-injection", "di", "ioc"]
 license = "MIT"
 
 [project.urls]
-Homepage = "https://github.com/misut/prion"
 Repository = "https://github.com/misut/prion"
 Issues = "https://github.com/misut/prion/issues"
 
 [build-system]
-requires = ["uv_build>=0.9.26,<0.10.0"]
+requires = ["uv_build>=0.11.0,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Add Python version classifiers, keywords, and project URLs
- Upgrade `uv_build` from 0.9.x to 0.11.x

## Test plan
- [x] `mise run test` passes (19 tests)
- [x] Build warning for uv_build version mismatch resolved