### PR TITLE
feat: add warm() for eager dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Providers can receive other dependencies as parameters. Parameter names are matc
 
 Circular dependencies are detected at resolve time with a `RuntimeError`.
 
+## Eager Initialization
+
+Use `warm()` to resolve all dependencies upfront. This validates that every provider is registered and detects circular dependencies at boot time.
+
+```pycon
+>>> syringe = AppSyringe()
+
+>>> @syringe.config
+... def create_config() -> dict:
+...     return {"debug": True}
+
+>>> @syringe.session
+... def create_session() -> dict:
+...     return {}
+
+>>> syringe.warm()
+
+```
+
 ## Lifecycle
 
 Use `reset()` to clear all cached singletons, or use the container as a context manager.

--- a/src/prion/syringe.py
+++ b/src/prion/syringe.py
@@ -12,6 +12,16 @@ class Syringe:
     def __init__(self) -> None:
         self._dependencies: dict[str, DependencyState[Any]] = {}
 
+    def warm(self) -> None:
+        for name in vars(type(self)):
+            if isinstance(getattr(type(self), name), Dependency):
+                # trigger descriptor __get__ to ensure DependencyState exists
+                getattr(self, name)
+        for name, state in self._dependencies.items():
+            if state._provider is None:
+                raise RuntimeError(f"no provider registered for: {name}")
+            state.resolve()
+
     def reset(self) -> None:
         for state in self._dependencies.values():
             state.reset()

--- a/tests/test_syringe.py
+++ b/tests/test_syringe.py
@@ -285,3 +285,52 @@ class TestOverride:
         with pytest.raises(KeyError, match="unknown dependency"):
             with container.override("nonexistent", lambda: "x"):
                 pass
+
+
+class TestWarm:
+    def test_warm_resolves_all_singletons(self) -> None:
+        container = Container()
+        call_count = 0
+
+        @container.value
+        def provide_value() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "hello"
+
+        @container.creator
+        def provide_creator() -> str:
+            return "world"
+
+        container.warm()
+        assert call_count == 1
+        assert container.value == "hello"
+
+    def test_warm_raises_on_missing_provider(self) -> None:
+        container = Container()
+
+        @container.value
+        def provide_value() -> str:
+            return "hello"
+
+        # creator has no provider
+        with pytest.raises(RuntimeError, match="no provider registered for: creator"):
+            container.warm()
+
+    def test_warm_detects_circular_dependency(self) -> None:
+        class Circular(Syringe):
+            a = single[str]()
+            b = single[str]()
+
+        container = Circular()
+
+        @container.a
+        def create_a(b: str) -> str:
+            return f"a({b})"
+
+        @container.b
+        def create_b(a: str) -> str:
+            return f"b({a})"
+
+        with pytest.raises(RuntimeError, match="circular dependency"):
+            container.warm()


### PR DESCRIPTION
## Summary
- Add `Syringe.warm()` to eagerly resolve all dependencies at boot time
- Validates provider registration and detects circular dependencies upfront
- Update README with eager initialization section

## Test plan
- [x] `mise run test` passes (22 tests)
- [x] `warm()` resolves all singletons eagerly
- [x] `warm()` raises on missing provider
- [x] `warm()` detects circular dependencies