### PR TITLE
ci: add mypy strict type checking alongside ty

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ uv = "latest"
 run = ["uvx ruff check", "uvx ruff format --check"]
 
 [tasks.check-type]
-run = "uvx ty check"
+run = ["uvx ty check", "uvx mypy src/"]
 
 [tasks.check]
 depends = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ resolution = "highest"
 [tool.pytest.ini_options]
 addopts = ["--doctest-glob=*.md"]
 
+[tool.mypy]
+strict = true
+warn_unused_ignores = false
+
 [tool.ruff.lint]
 ignore = ["F403"]
 


### PR DESCRIPTION
## Summary
- Add mypy with `strict = true` to type checking pipeline
- Run ty and mypy in parallel via `check-type` mise task
- Configure `warn_unused_ignores = false` to avoid conflict with ty-specific `type: ignore` comments

## Test plan
- [x] `uvx mypy src/` passes with 0 errors
- [x] `mise run test` passes (22 tests)