### PR TITLE
chore: upgrade GitHub Actions to Node.js 22 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
       - run: uv sync
       - run: mise run check
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
       - run: mise run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
       - run: uv build
       - run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always
 
@@ -29,7 +29,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
       - run: uv build
       - run: uv publish --trusted-publishing always


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6
- Upgrade `jdx/mise-action` from v2 to v4
- Resolves Node.js 20 deprecation warnings

## Test plan
- [x] `mise run test` passes (22 tests)
- [x] CI workflow uses updated action versions