### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,16 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+      - ".editorconfig"
+      - ".gitignore"
+      - ".claude/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- add PR concurrency and docs/config-only path ignores for CI cost control
- add monthly grouped Dependabot updates for GitHub Actions

## Validation
- git diff --check
- actionlint
- scanned workflows for removed legacy action references