### PR TITLE
chore: auto-merge successful Dependabot Actions PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,49 @@
+name: Dependabot Auto-Merge
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Merge successful Dependabot GitHub Actions PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          pr_number=$(
+            gh api "repos/$REPO/actions/runs/$RUN_ID/pulls" \
+              --jq 'map(select(.user.login == "dependabot[bot]" and (.head.ref | startswith("dependabot/github_actions/"))))[0].number // ""'
+          )
+
+          if [ -z "$pr_number" ]; then
+            echo "No Dependabot GitHub Actions PR found for workflow run $RUN_ID."
+            exit 0
+          fi
+
+          state=$(gh pr view "$pr_number" --repo "$REPO" --json state --jq '.state')
+          if [ "$state" != "OPEN" ]; then
+            echo "PR #$pr_number is $state; nothing to merge."
+            exit 0
+          fi
+
+          head_oid=$(gh pr view "$pr_number" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+          gh pr merge "$pr_number" \
+            --repo "$REPO" \
+            --squash \
+            --delete-branch \
+            --match-head-commit "$head_oid" \
+            --subject "chore(deps): update GitHub Actions dependencies" \
+            --body ""


### PR DESCRIPTION
## Summary
- add a workflow_run-based merge gate for Dependabot GitHub Actions PRs
- merge only successful CI runs from dependabot/github_actions/* branches
- use a fixed Conventional Commits squash title for automated merges

## Validation
- git diff --check
- actionlint