### PR TITLE
fix: resolve Dependabot auto-merge PR lookup

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,17 +19,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
 
+          if [[ "$HEAD_BRANCH" != dependabot/github_actions/* ]]; then
+            echo "Workflow run branch $HEAD_BRANCH is not a Dependabot GitHub Actions branch."
+            exit 0
+          fi
+
           pr_number=$(
-            gh api "repos/$REPO/actions/runs/$RUN_ID/pulls" \
-              --jq 'map(select(.user.login == "dependabot[bot]" and (.head.ref | startswith("dependabot/github_actions/"))))[0].number // ""'
+            gh pr list \
+              --repo "$REPO" \
+              --state open \
+              --author "app/dependabot" \
+              --head "$HEAD_BRANCH" \
+              --json number \
+              --jq '.[0].number // ""'
           )
 
           if [ -z "$pr_number" ]; then
-            echo "No Dependabot GitHub Actions PR found for workflow run $RUN_ID."
+            echo "No open Dependabot GitHub Actions PR found for branch $HEAD_BRANCH."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- stop calling the workflow-run pulls API that returns 404 in the auto-merge workflow
- use workflow_run.head_branch plus gh pr list to find open Dependabot GitHub Actions PRs
- keep the Dependabot branch guard before merge

## Validation
- inspected failing Dependabot Auto-Merge logs
- git diff --check
- actionlint